### PR TITLE
Removing Manifest, because it would also use graphiql in production

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,0 @@
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Add GraphiQL assets only in development env
+  config.assets.precompile += ["graphiql/rails/application.js", "graphiql/rails/application.css"]
 end


### PR DESCRIPTION
Which we don't want, and is prevented by the fact that GraphiQL is
installed only for certain envs.